### PR TITLE
Escape liquid tags in deepl translations

### DIFF
--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -24,6 +24,7 @@ module I18n::Tasks::Translators
     def translate_values(list, from:, to:, **options)
       results = []
       list.each_slice(BATCH_SIZE) do |parts|
+        parts = parts.map { |part| escape_liquid(part) }
         res = DeepL.translate(
           parts,
           to_deepl_source_locale(from),
@@ -36,13 +37,23 @@ module I18n::Tasks::Translators
           results += res.map(&:text)
         end
       end
-      results
+      results.map { |part| unescape_liquid(part) }
     end
 
     def options_for_translate_values(**options)
       extra_options = @i18n_tasks.translation_config[:deepl_options]&.symbolize_keys || {}
 
       extra_options.merge({ ignore_tags: %w[i18n] }).merge(options)
+    end
+
+    def escape_liquid(txt)
+      txt.gsub(/{{([^}]+)}}/, "<liquid-var:\\1>")
+         .gsub(/{%([^%]+)%}/, "<liquid-tag:\\1>")
+    end
+
+    def unescape_liquid(txt)
+      txt.gsub(/<liquid-var\:([^>]+)>/, "{{\\1}}")
+         .gsub(/<liquid-tag\:([^>]+)>/, "{%\\1%}")
     end
 
     def options_for_html


### PR DESCRIPTION
Quick and dirty solution to avoid translations of liquid tags:

* preg replace them with pseudo-xml tags
* replace back after translation.